### PR TITLE
Add ARM64 & ARM32v7 build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,36 @@
-FROM ekidd/rust-musl-builder:1.36.0 as builder
+# Original: https://github.com/knsd/ping-exporter
 
+# AMD64 Build
+FROM --platform=linux/amd64 ekidd/rust-musl-builder:1.36.0 as builder
 COPY Cargo.toml Makefile ./
 COPY src/ ./src/
-
 RUN make
 RUN strip /home/rust/src/target/x86_64-unknown-linux-musl/release/ping-exporter
-
 FROM alpine:latest
-
 WORKDIR /
 COPY --from=builder /home/rust/src/target/x86_64-unknown-linux-musl/release/ping-exporter ./
+ENTRYPOINT ["/ping-exporter"]
 
+# From: https://github.com/rust-cross/rust-musl-cross
+
+# ARM32v7 build
+FROM --platform=linux/arm32v7 messense/rust-musl-cross:armv7-musleabihf as builder
+COPY Cargo.toml Makefile ./
+COPY src/ ./src/
+RUN make
+RUN musl-strip /home/rust/src/target/armv7-unknown-linux-musleabihf/release/ping-exporter
+FROM alpine:latest
+WORKDIR /
+COPY --from=builder /home/rust/src/target/armv7-unknown-linux-musleabihf/release/ping-exporter ./
+ENTRYPOINT ["/ping-exporter"]
+
+# ARM64 build
+FROM --platform=linux/arm64 messense/rust-musl-cross:aarch64-musl as builder
+COPY Cargo.toml Makefile ./
+COPY src/ ./src/
+RUN make
+RUN musl-strip /home/rust/src/target/aarch64-unknown-linux-musl/release/ping-exporter
+FROM alpine:latest
+WORKDIR /
+COPY --from=builder /home/rust/src/target/aarch64-unknown-linux-musl/release/ping-exporter ./
 ENTRYPOINT ["/ping-exporter"]


### PR DESCRIPTION
Tested working on Raspberry Pi 4 (Debian 12.4)
`Linux 6.1.0-rpi7-rpi-v8 #1 SMP PREEMPT Debian 1:6.1.63-1+rpt1 (2023-11-24) aarch64 GNU/Linux`

`$ docker build -t ping-exporter .`
`$ docker run -d -p 9346:9346 --name=ping-exporter ping-exporter`
`$ curl http://localhost:9346/ping?target=1.1.1.1`
```
# HELP ping_resolve_time Time it take to resolve domain to an IP address
# TYPE ping_resolve_time gauge
ping_resolve_time{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 0
# HELP ping_packets_total Total number of sent pings
# TYPE ping_packets_total gauge
ping_packets_total{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 5
# HELP ping_packets_success Total number of success pings
# TYPE ping_packets_success gauge
ping_packets_success{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 5
# HELP ping_packets_failed Total number of failed pings
# TYPE ping_packets_failed gauge
ping_packets_failed{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 0
# HELP ping_packets_loss A percentage of failed pings from the total pings
# TYPE ping_packets_loss gauge
ping_packets_loss{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 0
# HELP ping_resolve_error Boolean metric if there's an error during the resolve (error message will be in "error" label)
# TYPE ping_resolve_error gauge
ping_resolve_error{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 0
# HELP ping_times A histogram of round-trip times
# TYPE ping_times histogram
ping_times_count{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 5
ping_times_bucket{le="11", count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 1
ping_times_bucket{le="12", count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 3
ping_times_bucket{le="16", count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 4
ping_times_bucket{le="17", count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 5
ping_times_bucket{le="+Inf", count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 5
ping_times_min{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 11
ping_times_max{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 17
ping_times_sum{count="5", ip="1.1.1.1", ping_timeout="1000", protocol="v4", resolve_timeout="1000", target="1.1.1.1"} 65
```

Nice :)